### PR TITLE
Sage snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Building with Sage
 
 Our system is our source of truth, providing everything you need to build the best experiences for all Kajabi entrepreneurs.
 
-Learn more https://sage-design-system.kajabi.com/pages/index
+Learn more at https://sage.kajabi.com

--- a/extension.js
+++ b/extension.js
@@ -24,25 +24,26 @@ function activate(context) {
 
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "kajabi-sage" is now active!');
+	console.log('Kajabi extension activated 😎');
 
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with  registerCommand
 	// The commandId parameter must match the command field in package.json
-	let disposable1 = vscode.commands.registerCommand('kajabi-sage.openSageReact', function () {
-		// The code you place here will be executed every time your command is executed
 
-		// Display a message box to the user
-		// vscode.window.showInformationMessage('Openning react docs!');
+	let sageDocsLink = vscode.commands.registerCommand('kajabi-sage.openSageDocs', function () {
+    vscode.window.showInformationMessage('Opening Sage Docs…');
+    vscode.env.openExternal(vscode.Uri.parse('https://sage.kajabi.com/'));
+	});
+
+	let sageStorybookLink = vscode.commands.registerCommand('kajabi-sage.openSageReact', function () {
+    vscode.window.showInformationMessage('Opening Sage Storybook…');
     vscode.env.openExternal(vscode.Uri.parse('https://sage-lib-storybook.herokuapp.com/'));
 	});
 
-	let disposable2 = vscode.commands.registerCommand('kajabi-sage.openSageDocs', function () {
-		// The code you place here will be executed every time your command is executed
 
-		// Display a message box to the user
-		// vscode.window.showInformationMessage('Opening Sage docs!');
-    vscode.env.openExternal(vscode.Uri.parse('https://sage-design-system.kajabi.com/pages/index'));
+	let sageSassDocsLink = vscode.commands.registerCommand('kajabi-sage.openSageSass', function () {
+		vscode.window.showInformationMessage('Opening Sage SassDocs…');
+    vscode.env.openExternal(vscode.Uri.parse('https://sage-lib-sassdocs.herokuapp.com/'));
 	});
 
   const sageElements = buttons.buttons.concat(accordions.accordions);
@@ -75,8 +76,9 @@ function activate(context) {
   //   context.subscriptions.push(disposable);
   // });
 
-	context.subscriptions.push(disposable1);
-	context.subscriptions.push(disposable2);
+	context.subscriptions.push(sageDocsLink);
+	context.subscriptions.push(sageStorybookLink);
+	context.subscriptions.push(sageSassDocsLink);
 }
 
 // This method is called when your extension is deactivated

--- a/package.json
+++ b/package.json
@@ -9,19 +9,37 @@
     "vscode": "^1.74.0"
   },
   "categories": [
+    "Snippets",
     "Other"
   ],
   "activationEvents": [
+    "onLanguage:javascriptreact",
+    "onLanguage:typescriptreact",
     "onCommand:kajabi-sage.openSageReact",
+    "onCommand:kajabi-sage.openSageSass",
     "onCommand:kajabi-sage.openSageDocs",
     "onCommand:kajabi-sage.sage"
   ],
   "main": "./extension.js",
   "contributes": {
+    "snippets": [
+      {
+        "language": "css",
+        "path": "./snippets/sagetokens.json"
+      },
+      {
+        "language": "scss",
+        "path": "./snippets/sagetokens.json"
+      }
+    ],
     "commands": [
       {
         "command": "kajabi-sage.openSageReact",
         "title": "Sage React Storybook"
+      },
+      {
+        "command": "kajabi-sage.openSageSass",
+        "title": "Sage SassDocs"
       },
       {
         "command": "kajabi-sage.openSageDocs",

--- a/snippets/sagetokens.json
+++ b/snippets/sagetokens.json
@@ -1,0 +1,67 @@
+{
+  "sage-border": {
+    "prefix": "sage-border",
+    "body": "sage-border(${1|light,default,radius-small,radius,radius-large,radius-x-large,radius-round|})$2",
+    "description": "System border style mixin. If empty, maps to the default value `rem(1px) solid sage-color(grey, 300)`"
+  },
+  "sage-breakpoint": {
+    "prefix": "sage-breakpoint",
+    "body": "sage-breakpoint(${1|xs-max,sm-min,sm-max,md-min,md-max,lg-min,lg-max,xl-min,xxl-min|})$2",
+    "description": "Breakpoint value for min-width or max-width sizes. If empty, maps to the default value `sm-max` (767px)"
+  },
+  "sage-color": {
+    "prefix": "sage-color",
+    "body": "sage-color(${1|primary,sage,yellow,red,orange,purple,grey,charcoal,white,black|}, ${2|100,200,300,400,500|})$3",
+    "description": "Sage color with (optional) tint/shade value"
+  },
+  "sage-color-combo": {
+    "prefix": "sage-color-combo",
+    "body": "sage-color-combo(${1|draft,published,info,locked,warning,danger|}, ${2|default,subtle,bold|}, ${3|foreground,foreground-accent,background,background-accent,icon-background-accent|})$4",
+    "description": "Sage color combos. Note that not all color types are available for combinations."
+  },
+  "sage-container": {
+    "prefix": "sage-container",
+    "body": "sage-container(${1|tiny,xs,sm,md,lg,xl,full|})$2",
+    "description": "Sage container size mixin. If empty, defaults to `md` (1200px)"
+  },
+  "sage-font-size": {
+    "prefix": "sage-font-size",
+    "body": "sage-font-size(${1|2xs,xs,sm,md,lg,xl,2xl,3xl,4xl|})$2",
+    "description": "Sage font-size mixin. If empty, defaults to `md`"
+  },
+  "sage-font-weight": {
+    "prefix": "sage-font-weight",
+    "body": "sage-font-weight(${1|regular,medium,semibold,bold|})$2",
+    "description": "Sage font-weight mixin. If empty, defaults to `regular`"
+  },
+  "sage-grid-template": {
+    "prefix": "sage-grid-template",
+    "body": "sage-grid-template(${1|e,i,s,t,m,o,se,si,ss,ot,om,oo,et,em,eo,it,im,io,st,sm,so,te,ti,ts,me,mi,ms,oe,oi,os,ete,eti,ets,eme,emi,ems,eoe,eoi,eos,ite,iti,its,ime,imi,ims,ioe,ioi,ios,ste,sti,sts,sme,smi,sms,soe,soi,sos|})$2",
+    "description": "Sage grid-template mixin. Uses predefined grid configurations based on morse code"
+  },
+  "sage-letter-spacing": {
+    "prefix": "sage-letter-spacing",
+    "body": "sage-letter-spacing(${1|xs,sm,md,lg|})$2",
+    "description": "Sage letter spacing mixin. When empty, will default to `sm` / rem(0.3px)"
+  },
+  "sage-line-height": {
+    "prefix": "sage-line-height",
+    "body": "sage-line-height(${1|xs,sm,md,lg,xl|})$2",
+    "description": "Sage line-height value. If empty, will default to `md` / sage-baseline(7)"
+  },
+  "sage-shadow": {
+    "prefix": "sage-shadow",
+    "body": "sage-shadow(${1|sm,md,lg,modal|})$2",
+    "description": "Sage box-shadow value. If empty, defaults to `md`"
+  },
+  "sage-spacing": {
+    "prefix": "sage-spacing",
+    "body": "sage-spacing(${1|3xs,2xs,xs,sm,md,lg,xl,2xl|})$2",
+    "description": "Sage spacing value. Empty values default to `md` / rem(24px)"
+  },
+  "sage-z-index": {
+    "prefix": "sage-z",
+    "body": "sage-z_index(${1|default,negative,raised,alert,underlay,nav,overlay,modal,priority,nuclear|}$2)$3",
+    "description": "Output system z-index value. Empty values are set to `default` (0) and can be optionally incremented"
+  }
+}

--- a/snippets/sagetokens.json
+++ b/snippets/sagetokens.json
@@ -1,38 +1,48 @@
 {
   "sage-border": {
     "prefix": "sage-border",
-    "body": "sage-border(${1|light,default,radius-small,radius,radius-large,radius-x-large,radius-round|})$2",
-    "description": "System border style mixin. If empty, maps to the default value `rem(1px) solid sage-color(grey, 300)`"
+    "body": "sage-border(${1|default,error,interactive,interactive-hover,radius-small,radius,radius-medium,radius-large,radius-x-large,radius-round,focus-outline|})$2",
+    "description": "System border style mixin. Omitted values are set to `default` value, `rem(1px) solid sage-color(grey, 300)`"
+  },
+  "sage-border-interactive": {
+    "prefix": "sage-border-interactive",
+    "body": "sage-border-interactive(${1|default,hover,focus,selected,error,error-focus,disabled|})$2",
+    "description": "System border interactive style mixin. Uses `box-shadow` to emulate border appearance."
   },
   "sage-breakpoint": {
     "prefix": "sage-breakpoint",
     "body": "sage-breakpoint(${1|xs-max,sm-min,sm-max,md-min,md-max,lg-min,lg-max,xl-min,xxl-min|})$2",
-    "description": "Breakpoint value for min-width or max-width sizes. If empty, maps to the default value `sm-max` (767px)"
+    "description": "Breakpoint value for min-width or max-width sizes. Omitted values default to `sm-max` (767px)"
   },
   "sage-color": {
     "prefix": "sage-color",
-    "body": "sage-color(${1|primary,sage,yellow,red,orange,purple,grey,charcoal,white,black|}, ${2|100,200,300,400,500|})$3",
+    "body": "sage-color(${1|primary,sage,grey,charcoal,yellow,red,orange,purple,white,black|}, ${2|100,200,300,400,500|})$3",
     "description": "Sage color with (optional) tint/shade value"
   },
   "sage-color-combo": {
     "prefix": "sage-color-combo",
-    "body": "sage-color-combo(${1|draft,published,info,locked,warning,danger|}, ${2|default,subtle,bold|}, ${3|foreground,foreground-accent,background,background-accent,icon-background-accent|})$4",
+    "body": "sage-color-combo(${1|draft,published,info,locked,warning,danger,primary|}, ${2|default,subtle,bold|}, ${3|foreground,foreground-accent,background,background-accent,icon-background-accent|})$4",
     "description": "Sage color combos. Note that not all color types are available for combinations."
   },
   "sage-container": {
     "prefix": "sage-container",
     "body": "sage-container(${1|tiny,xs,sm,md,lg,xl,full|})$2",
-    "description": "Sage container size mixin. If empty, defaults to `md` (1200px)"
+    "description": "Sage container size mixin. Omitted values default to `md` (520px)"
   },
   "sage-font-size": {
     "prefix": "sage-font-size",
-    "body": "sage-font-size(${1|2xs,xs,sm,md,lg,xl,2xl,3xl,4xl|})$2",
-    "description": "Sage font-size mixin. If empty, defaults to `md`"
+    "body": "sage-font-size(${1|xs,sm,md,lg,xl,2xl,3xl,4xl|})$2",
+    "description": "Sage font-size mixin. Omitted values default to `md`"
   },
   "sage-font-weight": {
     "prefix": "sage-font-weight",
     "body": "sage-font-weight(${1|regular,medium,semibold,bold|})$2",
-    "description": "Sage font-weight mixin. If empty, defaults to `regular`"
+    "description": "Sage font-weight mixin. Omitted values default to `regular`"
+  },
+  "sage-grid-gap-option": {
+    "prefix": "sage-grid-gap-options",
+    "body": "map-get($$sage-grid-gap-options, ${1|xs,sm,md,lg|})$2",
+    "description": "Outputs Sage grid gap spacing value."
   },
   "sage-grid-template": {
     "prefix": "sage-grid-template",
@@ -42,26 +52,26 @@
   "sage-letter-spacing": {
     "prefix": "sage-letter-spacing",
     "body": "sage-letter-spacing(${1|xs,sm,md,lg|})$2",
-    "description": "Sage letter spacing mixin. When empty, will default to `sm` / rem(0.3px)"
-  },
-  "sage-line-height": {
-    "prefix": "sage-line-height",
-    "body": "sage-line-height(${1|xs,sm,md,lg,xl|})$2",
-    "description": "Sage line-height value. If empty, will default to `md` / sage-baseline(7)"
+    "description": "Sage letter spacing mixin. Omitted values default to `sm` / rem(0.3px)"
   },
   "sage-shadow": {
     "prefix": "sage-shadow",
     "body": "sage-shadow(${1|sm,md,lg,modal|})$2",
-    "description": "Sage box-shadow value. If empty, defaults to `md`"
+    "description": "Sage box-shadow value. Omitted values default to `md`"
+  },
+  "sage-sidebar": {
+    "prefix": "sage-sidebar",
+    "body": "sage-sidebar(${1|sm,md,lg,modal|})$2",
+    "description": "Sage box-shadow value. Omitted values default to `md`"
   },
   "sage-spacing": {
     "prefix": "sage-spacing",
     "body": "sage-spacing(${1|3xs,2xs,xs,sm,md,lg,xl,2xl|})$2",
-    "description": "Sage spacing value. Empty values default to `md` / rem(24px)"
+    "description": "Sage spacing value. Omitted values default to `md` / rem(24px)"
   },
   "sage-z-index": {
     "prefix": "sage-z",
     "body": "sage-z_index(${1|default,negative,raised,alert,underlay,nav,overlay,modal,priority,nuclear|}$2)$3",
-    "description": "Output system z-index value. Empty values are set to `default` (0) and can be optionally incremented"
+    "description": "Output system z-index value. Omitted values are set to `default` (0). Values can be incremented to prevent collisions (use with caution)"
   }
 }


### PR DESCRIPTION
Updates to Kajabi VS Code extension
- Adds common Sage snippets for tokens. With this extension active, typing `sage-` within a stylesheet will autocomplete and display selectable lists for options with descriptions
- Updates documentation links