### PR TITLE
Adds a catalog-info.yaml to register with Radiator

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,6 +4,12 @@ metadata:
   name: vskajabi
   description: |
     VSCode extension for working with Sage @ Kajabi
+  tags:
+    - vscode
+    - extension
+    - javascript
+    - typescript
+    - sage
   annotations:
     backstage.io/source-location: url:https://github.com/Kajabi/vskajabi/tree/main
     github.com/project-slug: Kajabi/vskajabi

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: vskajabi
+  description: |
+    VSCode extension for working with Sage @ Kajabi
+  annotations:
+    backstage.io/source-location: url:https://github.com/Kajabi/vskajabi/tree/main
+    github.com/project-slug: Kajabi/vskajabi
+spec:
+  type: library
+  owner: design-system-services
+  lifecycle: experimental


### PR DESCRIPTION
This adds a `catalog-info.yaml` document to ensure the repository is registered with Radiator. Reach out to @Kajabi/standard-model with any questions.